### PR TITLE
Unable to see comments when line highlight is enabled.

### DIFF
--- a/an-old-hope.tmTheme
+++ b/an-old-hope.tmTheme
@@ -22,7 +22,7 @@
 				<key>invisibles</key>
 				<string>#767676</string>
 				<key>lineHighlight</key>
-				<string>#767676</string>
+				<string>#2f3542</string>
 				<key>selection</key>
 				<string>#767676</string>
 			</dict>


### PR DESCRIPTION
Comments are not visible with the current color configuration

**Original configuration**

![an-old-hope-highlight-enable-issue](https://user-images.githubusercontent.com/1837650/38491015-fca74a10-3bea-11e8-9234-1fbba063cbed.png)

**Fixed version**

![an-old-hope-highlight-enable-fix](https://user-images.githubusercontent.com/1837650/38491014-fc8bd2ee-3bea-11e8-8584-a83537aab657.png)

